### PR TITLE
deploy: Add deployment via esptool.py

### DIFF
--- a/deploy/esptool/Makefile
+++ b/deploy/esptool/Makefile
@@ -1,0 +1,32 @@
+#define a help message
+deploy_help+="\nesptool - Flash the firmware via esptool"
+
+#the deployment action
+
+#GP0 - Loader GPIO
+#GP1 - reset
+#Press both.
+#release reset.
+#sleep 300 ms
+#release boot
+define tobootloader
+	pl2303gpio --gpio=0 --out=0 --gpio=1 --out=0 \
+	--gpio=1 --in --sleep 50 \
+	--gpio=0 --in
+endef
+
+define reset
+	pl2303gpio --gpio=1 --out=0 --gpio=1 --in
+endef
+
+root=$(call check_root,$(CONFIG_DEPLOY_ROOT))
+esptool=$(call unquote, $(CONFIG_DEPLOY_ESPTOOL_BIN))
+
+esptool:
+ifeq ($(CONFIG_DEPLOY_ESPTOOL_PL2303),y)
+	$(root) $(tobootloader)
+endif
+	$(root) $(esptool) --port $(CONFIG_DEPLOY_ESPTOOL_PORT) write_flash $(CONFIG_DEPLOY_ESPTOOL_ADDRESS) $(IMAGENAME).rom
+ifeq ($(CONFIG_DEPLOY_ESPTOOL_PL2303),y)
+	$(root) $(reset)
+endif

--- a/deploy/esptool/kcnf
+++ b/deploy/esptool/kcnf
@@ -1,0 +1,22 @@
+menuconfig DEPLOY_ESPTOOL
+bool "esptool"
+depends on ARCH_ESP8266
+
+  if DEPLOY_ESPTOOL
+
+  config DEPLOY_ESPTOOL_BIN
+  string "esptool.py binary name"
+  default "esptool.py"
+
+  config DEPLOY_ESPTOOL_PORT
+  string "Port"
+  default "/dev/ttyUSB0"
+
+  config DEPLOY_ESPTOOL_ADDRESS
+  string "Flash address"
+  default "0x00000"
+
+  config DEPLOY_ESPTOOL_PL2303
+  bool "Use PL2303 GPIO to reset/run"
+
+  endif


### PR DESCRIPTION
Add a deployment option to deploy via esptool.py. It's basically same approach as in [esp8266-frankenstein][1].

[1]: https://github.com/nekromant/esp8266-frankenstein/blob/2920c66b985692a3041f36b3a7e8552a3c0fda18/Makefile