### PR TITLE
esp8266: Add option to specify SDK path

### DIFF
--- a/src/arch/esp8266/arch.mk
+++ b/src/arch/esp8266/arch.mk
@@ -46,7 +46,12 @@ endif
 
 ELFFLAGS  += -lgcc -Wl,--end-group
 
-LDFLAGS	  +=  $(COMMON_LDFLAGS)
+ifneq ($(CONFIG_ESP8266_SDK),)
+CFLAGS    += -I$(CONFIG_ESP8266_SDK)/include
+ELFFLAGS  += -L$(CONFIG_ESP8266_SDK)/lib
+endif
+
+LDFLAGS   += $(COMMON_LDFLAGS)
 ELFFLAGS  += $(COMMON_LDFLAGS) 
 
 #FW_FILE_1_ARGS	= -bo $@ -bs .text -bs .data -bs .rodata -bc -ec

--- a/src/arch/esp8266/kcnf
+++ b/src/arch/esp8266/kcnf
@@ -8,6 +8,12 @@ config ESP8266_LIBC_IROM
 bool "Use IROM version of libc"
 default n
 
+config ESP8266_SDK
+string "External SDK path"
+help
+  If you compiled esp-open-sdk without STANDALONE=Y, specify
+  your SDK path here.
+
 menu "Configure libraries to link against"
 
 config ESP8266_BLOB_MAIN


### PR DESCRIPTION
As some users might build `esp-open-sdk` without `STANDALONE=y` (to be able to use multiple versions of the SDK), this option allows them to specify a path to their SDK folder.