### PR TITLE
esp8266: Replace esptool by esptool.py

### DIFF
--- a/src/arch/esp8266/arch.mk
+++ b/src/arch/esp8266/arch.mk
@@ -49,12 +49,6 @@ ELFFLAGS  += -lgcc -Wl,--end-group
 LDFLAGS	  +=  $(COMMON_LDFLAGS)
 ELFFLAGS  += $(COMMON_LDFLAGS) 
 
-#FW_FILE_1_ARGS	= -bo $@ -bs .text -bs .data -bs .rodata -bc -ec
-#FW_FILE_2_ARGS	= -es .irom0.text $@ -ec
-
-FW_FILE_1_ARGS	= -bo $@ -bs .text -bs .data -bs .rodata -bc -ec
-FW_FILE_2_ARGS	= -es .irom0.text $@ -ec
-
 ifeq ($(CONFIG_ESP8266_FORCE_IROM),y)
 before-link+=_move_code_to_irom
 _move_code_to_irom: builtin 
@@ -66,11 +60,8 @@ _move_code_to_irom: builtin
 	done
 endif
 
-$(IMAGENAME)-$(FW_FILE_1).bin: $(IMAGENAME).elf
-	esptool -eo $< $(FW_FILE_1_ARGS)  
-
-$(IMAGENAME)-$(FW_FILE_2).bin: $(IMAGENAME).elf
-	esptool -eo $< $(FW_FILE_2_ARGS) 
+$(IMAGENAME)-%.bin: $(IMAGENAME).elf
+    esptool.py elf2image -o $(IMAGENAME)- $(IMAGENAME).elf
 
 $(IMAGENAME).rom: $(IMAGENAME)-$(FW_FILE_1).bin $(IMAGENAME)-$(FW_FILE_2).bin
 	dd if=/dev/zero of=$(@) bs=1K count=512


### PR DESCRIPTION
As mentioned in nekromant/esp8266-frankenstein#14, `esptool` can be replaced by `esptool.py`.

This patch depends on the `-o` option of the `elf2image` command, which is not yet available if you use `esp-open-sdk`. As soon as pfalcon/esp-open-sdk#13 is resolved, all users are able upgrade easily.