### PR TITLE
Experimental

### DIFF
--- a/src/arch/esp8266/include-sdk/espmissingincludes.h
+++ b/src/arch/esp8266/include-sdk/espmissingincludes.h
@@ -41,6 +41,7 @@ void ets_delay_us (int us);
 
 void pvPortFree(void *ptr);
 void *pvPortMalloc(size_t xWantedSize);
+void *pvPortRealloc(void* ptr, size_t xWantedSize);
 void *pvPortZalloc(size_t);
 void uart_div_modify(int no, unsigned int freq);
 void vPortFree(void *ptr);

--- a/src/arch/esp8266/include-sdk/espmissingincludes.h
+++ b/src/arch/esp8266/include-sdk/espmissingincludes.h
@@ -1,0 +1,42 @@
+
+// https://github.com/mziwisky/esp8266-dev/blob/master/esphttpd/include/espmissingincludes.h
+
+#ifndef ESPMISSINGINCLUIDES_H
+#define ESPMISSINGINCLUIDES_H
+
+#include <ets_sys.h>
+
+//Missing function prototypes in include folders. Gcc will warn on these if we don't define 'em anywhere.
+//MOST OF THESE ARE GUESSED! but they seem to swork and shut up the compiler.
+
+int atoi(const char *nptr);
+void ets_install_putc1(void *routine);
+void ets_isr_attach(int intr, void *handler, void *arg);
+void ets_isr_mask(unsigned intr);
+void ets_isr_unmask(unsigned intr);
+int ets_memcmp(const void *s1, const void *s2, size_t n);
+void *ets_memcpy(void *dest, const void *src, size_t n);
+void *ets_memset(void *s, int c, size_t n);
+int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
+int ets_str2macaddr(void *, void *);
+int ets_strcmp(const char *s1, const char *s2);
+char *ets_strcpy(char *dest, const char *src);
+size_t ets_strlen(const char *s);
+int ets_strncmp(const char *s1, const char *s2, int len);
+char *ets_strncpy(char *dest, const char *src, size_t n);
+char *ets_strstr(const char *haystack, const char *needle);
+void ets_timer_arm_new(ETSTimer *a, int b, int c, int isMstimer);
+void ets_timer_disarm(ETSTimer *a);
+void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *fn, void *parg);
+int os_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+void pvPortFree(void *ptr);
+void *pvPortMalloc(size_t xWantedSize);
+void *pvPortZalloc(size_t);
+void uart_div_modify(int no, unsigned int freq);
+void vPortFree(void *ptr);
+void *vPortMalloc(size_t xWantedSize);
+
+int ets_uart_printf(const char *fmt, ...);
+
+#endif

--- a/src/arch/esp8266/include-sdk/espmissingincludes.h
+++ b/src/arch/esp8266/include-sdk/espmissingincludes.h
@@ -9,6 +9,7 @@
 //Missing function prototypes in include folders. Gcc will warn on these if we don't define 'em anywhere.
 //MOST OF THESE ARE GUESSED! but they seem to swork and shut up the compiler.
 
+int skip_atoi(const char **nptr);
 int atoi(const char *nptr);
 void ets_install_putc1(void *routine);
 void ets_isr_attach(int intr, void *handler, void *arg);
@@ -17,6 +18,7 @@ void ets_isr_unmask(unsigned intr);
 int ets_memcmp(const void *s1, const void *s2, size_t n);
 void *ets_memcpy(void *dest, const void *src, size_t n);
 void *ets_memset(void *s, int c, size_t n);
+void ets_bzero(void *s, size_t n);
 int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
 int ets_str2macaddr(void *, void *);
 int ets_strcmp(const char *s1, const char *s2);
@@ -28,8 +30,15 @@ char *ets_strstr(const char *haystack, const char *needle);
 void ets_timer_arm_new(ETSTimer *a, int b, int c, int isMstimer);
 void ets_timer_disarm(ETSTimer *a);
 void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *fn, void *parg);
-int os_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
-int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+int os_random (void);
+
+void ets_wdt_enable(void);
+void ets_wdt_disable(void);
+void wdt_feed(void);
+
+
+void ets_delay_us (int us);
+
 void pvPortFree(void *ptr);
 void *pvPortMalloc(size_t xWantedSize);
 void *pvPortZalloc(size_t);
@@ -37,6 +46,13 @@ void uart_div_modify(int no, unsigned int freq);
 void vPortFree(void *ptr);
 void *vPortMalloc(size_t xWantedSize);
 
-int ets_uart_printf(const char *fmt, ...);
+int ets_uart_printf(const char *fmt, ...)                         __attribute__((format(printf, 1, 2)));
+int os_printf_plus (const char *fmt, ...)                         __attribute__((format(printf, 1, 2)));
+int os_snprintf    (char *str, size_t size, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+#if 0
+int os_printf      (const char *fmt, ...)                         __attribute__((format(printf, 1, 2)));
+#else
+#define os_printf os_printf_plus
+#endif
 
 #endif

--- a/src/arch/esp8266/include-sdk/osapi.h
+++ b/src/arch/esp8266/include-sdk/osapi.h
@@ -45,6 +45,4 @@
 #define os_sprintf  ets_sprintf
 #define os_update_cpu_frequency ets_update_cpu_frequency
 
-#define os_printf	os_printf_plus
-
 #endif

--- a/src/arch/esp8266/include-sdk/osapi.h
+++ b/src/arch/esp8266/include-sdk/osapi.h
@@ -44,5 +44,6 @@
 #define os_sprintf  ets_sprintf
 #define os_update_cpu_frequency ets_update_cpu_frequency
 
-#endif
+#define os_printf	os_printf_plus
 
+#endif

--- a/src/arch/esp8266/include-sdk/osapi.h
+++ b/src/arch/esp8266/include-sdk/osapi.h
@@ -7,6 +7,7 @@
 
 #include <string.h>
 #include "user_config.h"
+#include "espmissingincludes.h"
 
 #define os_bzero ets_bzero
 #define os_delay_us ets_delay_us

--- a/src/arch/esp8266/include-sdk/user_interface.h
+++ b/src/arch/esp8266/include-sdk/user_interface.h
@@ -173,6 +173,7 @@ struct station_info {
 };
 
 struct station_info * wifi_softap_get_station_info(void);
+int wifi_softap_set_station_info(uint8_t *addr, struct ip_addr *adr);
 void wifi_softap_free_station_info(void);
 
 #define STATION_IF      0x00
@@ -201,5 +202,7 @@ void wifi_set_promiscuous_rx_cb(wifi_promiscuous_cb_t cb);
 uint8 wifi_station_get_current_ap_id(void);
 bool wifi_station_ap_change(uint8 current_ap_id);
 bool wifi_station_ap_number_set(uint8 ap_number);
+
+void system_station_got_ip_set(ip_addr_t * ip_addr, ip_addr_t *sn_mask, ip_addr_t *gw_addr);
 
 #endif

--- a/src/arch/esp8266/include-sdk/user_interface.h
+++ b/src/arch/esp8266/include-sdk/user_interface.h
@@ -205,4 +205,6 @@ bool wifi_station_ap_number_set(uint8 ap_number);
 
 void system_station_got_ip_set(ip_addr_t * ip_addr, ip_addr_t *sn_mask, ip_addr_t *gw_addr);
 
+void system_pp_recycle_rx_pkt (void*);
+
 #endif

--- a/src/arch/esp8266/include-sdk/user_interface.h
+++ b/src/arch/esp8266/include-sdk/user_interface.h
@@ -79,6 +79,10 @@ typedef void (* init_done_cb_t)(void);
 
 void system_init_done_cb(init_done_cb_t cb);
 
+uint16 system_adc_read(void);
+
+const char *system_get_sdk_version(void);
+
 #define NULL_MODE       0x00
 #define STATION_MODE    0x01
 #define SOFTAP_MODE     0x02

--- a/src/arch/esp8266/ld/eagle.rom.addr.v6.ld
+++ b/src/arch/esp8266/ld/eagle.rom.addr.v6.ld
@@ -337,6 +337,9 @@ PROVIDE ( xthal_set_intclear = 0x4000dd60 );
 PROVIDE ( xthal_spill_registers_into_stack_nw = 0x4000e320 );
 PROVIDE ( xthal_window_spill = 0x4000e324 );
 PROVIDE ( xthal_window_spill_nw = 0x4000e320 );
+PROVIDE ( SPI_read_status = 0x400043c8 );
+PROVIDE ( SPI_write_status = 0x40004400 );
+PROVIDE ( SPI_write_enable = 0x4000443c );
 PROVIDE ( Wait_SPI_Idle = 0x4000448c );
 
 PROVIDE ( Te0 = 0x3fffccf0 );

--- a/src/arch/esp8266/newlib-dummies.c
+++ b/src/arch/esp8266/newlib-dummies.c
@@ -1,7 +1,7 @@
 /* These newlib stubs are borrowed and adapted from 
     http://caves.org/section/commelect/DUSI/openmag/src/hacks/lpc21xx/com/
     Original copyright notice follows
-
+*/
 /************************************************************************/
 /* Copyright 2003/12/27 Aeolus Development				*/
 /* All rights reserved.							*/


### PR DESCRIPTION
Make esp8266-frankenstein compile with current version of esp-open-sdk (0.9.5 final 3fb1417d385eef14f1e4fae5e1b9277b60c4bc81)
(it works after flashing)