### PR TITLE
Detect missing .config file and prevent undefined behaviour 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ Kconfig:=$(SRCDIR)/kcnf
 KVersion:=$(ANTARES_DIR)/version.kcnf
 
 
-PHONY+=deftarget deploy build collectinfo clean
+PHONY+=deftarget deploy build collectinfo clean ensure_config
 MAKEFLAGS:=-r
 
 IMAGENAME=$(call unquote,$(CONFIG_IMAGE_DIR))/$(call unquote,$(CONFIG_IMAGE_FILENAME))
@@ -124,6 +124,9 @@ graph-%:
 deploy-help:
 	$(Q)$(MAKE) -f $(ANTARES_DIR)/make/Makefile.deploy help
 
+ensure_config:
+	$(Q)echo "Please create a new .config file by running make menuconfig"
+
 #For deployment autocompletion
 define deploy_dummy
 deploy-$(1): real-deploy-$(1)
@@ -137,4 +140,11 @@ $(foreach d,$(DEPLOY), $(eval $(call deploy_dummy,$(d))))
 
 .PHONY: $(PHONY)
 
+# If .config doesnt exist yet the following line will fail...
+# On debian wheezy with make 3.8.1-8.2 it actually crashes make (debian bug #780778)
+ifeq ($(strip $(CONFIG_MAKE_DEFTARGET)),)
+.DEFAULT_GOAL := ensure_config
+else
 .DEFAULT_GOAL := $(subst ",, $(CONFIG_MAKE_DEFTARGET))
+endif
+


### PR DESCRIPTION
(or crash with debian bug [#780778](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780778))

I managed to rename my .config file and when I typed `make` it actually segfaulted (Believe it or not!)
Whether it segfaults or not, this patch will ensure clean behaviour (specifically, a message telling the user to create a .config file) if the .config file is missing
