### PR TITLE
Improve instructions on what to do when no .config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,8 @@ graph-%:
 	$(Q)$(ANTARES_DIR)/scripts/visualise_make $*
 
 .config:
-	@echo "Missing configuration file ($(tb_red).config$(col_rst)). Please run configuation tool (menuconfig, etc))"
+	@echo "Missing configuration file ($(tb_red).config$(col_rst))."
+	@echo "Please run configuation tool, e.g. 'make menuconfig', or 'make defconfig' if supported."
 
 #Help needs a dedicated rule, so that it won't invoke build as it normally does
 deploy-help:

--- a/kcnf
+++ b/kcnf
@@ -32,7 +32,7 @@ endmenu
 
 menu "Deployment settings"
      config DEPLOY_ROOT
-     bool "Run deploy commands with superuser priveledges"
+     bool "Run deploy commands with superuser privileges"
      help
 	Pick this, if you're missing udev rules
 


### PR DESCRIPTION
Shows `make defconfig` as an option as well if no .config file present (useful for ESP8266 at least)
Also fix minor spelling typo